### PR TITLE
🚨 models ordering, ' ' syntax errors.

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -3,27 +3,6 @@ from django.urls import reverse
 from datetime import date
 
 
-class Post(models.Model):
-    post_title = models.CharField(max_length=100, help_text='Enter a title')
-    post_created_at = models.DateTimeField(auto_now_add=True)
-    post_updated_at = models.DateTimeField(auto_now=True)
-
-    author = models.ForeignKey('Author', on_delete=models.SET_DEFAULT, default=None, null=True)
-
-    description = models.TextField(max_length=1000, help_text='Enter a brief description of this post')
-    comment = models.ForeignKey('Comment', on_delete=models.CASCADE)
-    commenter = models.ForeignKey('Commenter', on_delete=models.CASCADE)
-
-    def __str__(self):
-        return self.post_title
-
-    def get_absolute_url(self):
-        return reverse('post-detail', args=[str(self.id)])
-
-    # Metadata
-    class Meta:
-        ordering = ['-post_created_at']
-    
 class TimeStampMixin(models.Model):
     # see https://stackoverflow.com/a/57971729/5965865
     created_at = models.DateTimeField(auto_now_add=True)
@@ -44,6 +23,34 @@ class Author(TimeStampMixin):
     # def get_absolute_url(self):
     #     return reverse('post-detail', args=[str(self.id)])
 
+
+class Post(models.Model):
+    post_title = models.CharField(max_length=100, help_text='Enter a title')
+    post_created_at = models.DateTimeField(auto_now_add=True)
+    post_updated_at = models.DateTimeField(auto_now=True)
+
+    author = models.ForeignKey(Author, on_delete=models.SET_DEFAULT, default=None, null=True)
+
+    description = models.TextField(max_length=1000, help_text='Enter a brief description of this post')
+
+    def __str__(self):
+        return self.post_title
+
+    def get_absolute_url(self):
+        return reverse('post-detail', args=[str(self.id)])
+
+    # Metadata
+    class Meta:
+        ordering = ['-post_created_at']
+
+
+class Commenter(models.Model):
+    commenter_username = models.CharField(max_length=20)
+    
+    def __str__(self):
+        return self.commenter_username
+
+
 class Comment(TimeStampMixin):
      # see https://stackoverflow.com/a/57971729/5965865
 
@@ -51,7 +58,8 @@ class Comment(TimeStampMixin):
     comment_text = models.TextField(max_length=1000, help_text='Write your comment here')
     comment_created_at = models.DateTimeField(auto_now_add=True)
     comment_updated_at = models.DateTimeField(auto_now=True)
-    commenter = models.ForeignKey('Commenter', on_delete=models.SET_DEFAULT, default=None, null=True)
+    commenter = models.ForeignKey(Commenter, on_delete=models.SET_DEFAULT, default=None, null=True)
+    post = models.ForeignKey(Post, on_delete=models.SET_DEFAULT, default=None)
 
     class Meta:
         ordering = ['comment_created_at']
@@ -62,8 +70,3 @@ class Comment(TimeStampMixin):
     # def get_absolute_url(self):
     #     return reverse('post-detail', args=[str(self.id)])
 
-class Commenter(models.Model):
-    commenter_username = models.CharField(max_length=20)
-    
-    def __str__(self):
-        return self.commenter_username


### PR DESCRIPTION
Note:
when you make a foreign key field just pass the model as it is, not as 'STRING'.